### PR TITLE
THIS PC handling

### DIFF
--- a/Windows/ProactiveRemediations/Detection-RenameThisPCIcon_USER.ps1
+++ b/Windows/ProactiveRemediations/Detection-RenameThisPCIcon_USER.ps1
@@ -1,0 +1,21 @@
+﻿$RegPath = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\CLSID\{20D04FE0-3AEA-1069-A2D8-08002B30309D}'
+$ThisPCName = $env:COMPUTERNAME
+
+try
+{
+   if (!(Test-Path -LiteralPath $RegPath -ErrorAction Stop))
+   {
+      exit 1
+   }
+
+   if (!((Get-ItemPropertyValue -LiteralPath $RegPath -Name '(default)' -ErrorAction Stop) -eq $ThisPCName))
+   {
+      exit 1
+   }
+}
+catch
+{
+   exit 1
+}
+
+exit 0

--- a/Windows/ProactiveRemediations/Detection-ShowThisPCIcon_USER.ps1
+++ b/Windows/ProactiveRemediations/Detection-ShowThisPCIcon_USER.ps1
@@ -1,0 +1,20 @@
+﻿$RegPath = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\HideDesktopIcons\NewStartPanel'
+
+try
+{
+   if (!(Test-Path -LiteralPath $RegPath -ErrorAction Stop))
+   {
+      exit 1
+   }
+
+   if (!((Get-ItemPropertyValue -LiteralPath $RegPath -Name '{20D04FE0-3AEA-1069-A2D8-08002B30309D}' -ErrorAction Stop) -eq 0))
+   {
+      exit 1
+   }
+}
+catch
+{
+   exit 1
+}
+
+exit 0

--- a/Windows/ProactiveRemediations/Remediation-RenameThisPCIcon_USER.ps1
+++ b/Windows/ProactiveRemediations/Remediation-RenameThisPCIcon_USER.ps1
@@ -1,0 +1,24 @@
+﻿$RegPath = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\CLSID\{20D04FE0-3AEA-1069-A2D8-08002B30309D}'
+$ThisPCName = $env:COMPUTERNAME
+
+if ((Test-Path -LiteralPath $RegPath) -ne $true)
+{
+   $paramNewItem = @{
+      Path        = $RegPath
+      Force       = $true
+      Confirm     = $false
+      ErrorAction = 'SilentlyContinue'
+   }
+   $null = (New-Item @paramNewItem)
+}
+
+$paramNewItemProperty = @{
+   LiteralPath  = $RegPath
+   Name         = '(default)'
+   Value        = $ThisPCName
+   PropertyType = 'String'
+   Force        = $true
+   Confirm      = $false
+   ErrorAction  = 'SilentlyContinue'
+}
+$null = (New-ItemProperty @paramNewItemProperty)

--- a/Windows/ProactiveRemediations/Remediation-ShowThisPCIcon_USER.ps1
+++ b/Windows/ProactiveRemediations/Remediation-ShowThisPCIcon_USER.ps1
@@ -1,0 +1,23 @@
+﻿$RegPath = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\HideDesktopIcons\NewStartPanel'
+
+if ((Test-Path -LiteralPath $RegPath) -ne $true)
+{
+   $paramNewItem = @{
+      Path        = $RegPath
+      Force       = $true
+      Confirm     = $false
+      ErrorAction = 'SilentlyContinue'
+   }
+   $null = (New-Item @paramNewItem)
+}
+
+$paramNewItemProperty = @{
+   LiteralPath  = $RegPath
+   Name         = '{20D04FE0-3AEA-1069-A2D8-08002B30309D}'
+   Value        = 0
+   PropertyType = 'DWord'
+   Force        = $true
+   Confirm      = $false
+   ErrorAction  = 'SilentlyContinue'
+}
+$null = (New-ItemProperty @paramNewItemProperty)


### PR DESCRIPTION
This batch contains the following:

- Show THIS PC on the User's Desktop
- Rename THIS PC to match the Hostname

All of the scripts need to run in the user's context, because it changes the HKCU part of the registry.