### PR TITLE
Disable Downfall security mitigation for maximum CPU performance

### DIFF
--- a/Windows/ProactiveRemediations/Detection-DisableDownfallSecurityMitigation.ps1
+++ b/Windows/ProactiveRemediations/Detection-DisableDownfallSecurityMitigation.ps1
@@ -1,0 +1,26 @@
+﻿#requires -Version 5.0
+
+# Disable Downfall security mitigation for maximum CPU performance
+# https://support.microsoft.com/en-us/topic/kb5029778-how-to-manage-the-vulnerability-associated-with-cve-2022-40982-d461157c-0411-4a91-9fc5-9b29e0fe2782
+
+$RegPath = 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management'
+
+try 
+{
+   if (!(Test-Path -LiteralPath $RegPath -ErrorAction SilentlyContinue))
+   {
+      Exit 1
+   }
+
+	
+   if (!((Get-ItemPropertyValue -LiteralPath $RegPath -Name 'FeatureSettingsOverride' -ErrorAction SilentlyContinue) -eq 33554432))
+   {
+      Exit 1
+   }
+}
+catch
+{
+   Exit 1
+}
+
+Exit 0

--- a/Windows/ProactiveRemediations/Remediation-DisableDownfallSecurityMitigation.ps1
+++ b/Windows/ProactiveRemediations/Remediation-DisableDownfallSecurityMitigation.ps1
@@ -1,0 +1,13 @@
+﻿#requires -Version 1.0
+
+# Disable Downfall security mitigation for maximum CPU performance
+# https://support.microsoft.com/en-us/topic/kb5029778-how-to-manage-the-vulnerability-associated-with-cve-2022-40982-d461157c-0411-4a91-9fc5-9b29e0fe2782
+
+$RegPath = 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management'
+
+if ((Test-Path -LiteralPath $RegPath -ErrorAction SilentlyContinue) -ne $true)
+{
+   $null = (New-Item -Path $RegPath -Force -Confirm:$false -ErrorAction SilentlyContinue)
+}
+
+$null = (New-ItemProperty -LiteralPath $RegPath -Name 'FeatureSettingsOverride' -Value 33554432 -PropertyType DWord -Force -Confirm:$false -ErrorAction SilentlyContinue)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add scripts to **Disable Downfall security mitigation for maximum CPU performance** with Intune.

## Motivation and Context

Sometime performance with mitigations can cause business impact. It is a fine line, to keep systems secure or to get the most out of existing systems.

We do not recommend running this remediation against all your systems! Please choose wisely where you really need the performe and accept the potential security risk.

## How Has This Been Tested?

- System with another value set
- System without the registry key
- System where the mitigation was already applied

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (_non-breaking change which fixes an issue_)
- [X] New feature (_non-breaking change which adds functionality_)
- [ ] Breaking change (_fix or feature that would cause existing functionality to change_)

