### PR TITLE
Prevent Windows Copilot/Copilot+ and Windows Recall from being installed

### DIFF
--- a/Windows/ProactiveRemediations/Detection-NoCopilotPlusAndRecall.ps1
+++ b/Windows/ProactiveRemediations/Detection-NoCopilotPlusAndRecall.ps1
@@ -1,0 +1,39 @@
+﻿# Detection: Prevent Windows Copilot/Copilot+ and Windows Recall from being installed from updates
+
+try
+{
+   #region Copilot
+   $CopilotRegPath = 'HKLM:\Software\Policies\Microsoft\Windows\WindowsCopilot'
+
+   if (!(Test-Path -LiteralPath $CopilotRegPath -ErrorAction SilentlyContinue))
+   {
+      exit 1
+   }
+
+   if (!((Get-ItemPropertyValue -LiteralPath $CopilotRegPath -Name 'TurnOffWindowsCopilot' -ErrorAction SilentlyContinue) -eq 1))
+   {
+      exit 1
+   }
+   #endregion Copilot
+
+   #region Recall
+   $RecallRegPath = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsAI'
+
+   if (!(Test-Path -LiteralPath $RecallRegPath -ErrorAction SilentlyContinue))
+   {
+      exit 1
+   }
+
+   if (!((Get-ItemPropertyValue -LiteralPath $RecallRegPath -Name 'DisableAIDataAnalysis' -ErrorAction SilentlyContinue) -eq 1))
+   {
+      exit 1
+   }
+   #endregion Recall
+}
+catch
+{
+   exit 1
+}
+
+
+exit 0

--- a/Windows/ProactiveRemediations/Remediation-NoCopilotPlusAndRecall.ps1
+++ b/Windows/ProactiveRemediations/Remediation-NoCopilotPlusAndRecall.ps1
@@ -1,0 +1,53 @@
+﻿# Remediation: Prevent Windows Copilot/Copilot+ and Windows Recall from being installed from updates
+
+#region Copilot
+$CopilotRegPath = 'HKLM:\Software\Policies\Microsoft\Windows\WindowsCopilot'
+
+if ((Test-Path -LiteralPath $CopilotRegPath -ErrorAction SilentlyContinue) -ne $true)
+{
+   $paramNewItem = @{
+      Path        = $CopilotRegPath
+      Force       = $true
+      Confirm     = $false
+      ErrorAction = 'Stop'
+   }
+   $null = (New-Item @paramNewItem)
+}
+
+$paramNewItemProperty = @{
+   LiteralPath  = $CopilotRegPath
+   Name         = 'TurnOffWindowsCopilot'
+   Value        = 1
+   PropertyType = 'DWord'
+   Force        = $true
+   Confirm      = $false
+   ErrorAction  = 'Stop'
+}
+$null = (New-ItemProperty @paramNewItemProperty)
+#endregion Copilot
+
+#region Recall
+$RecallRegPath = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsAI'
+
+if ((Test-Path -LiteralPath $RecallRegPath -ErrorAction SilentlyContinue) -ne $true)
+{
+   $paramNewItem = @{
+      Path        = $RecallRegPath
+      Force       = $true
+      Confirm     = $false
+      ErrorAction = 'Stop'
+   }
+   $null = (New-Item @paramNewItem)
+}
+
+$paramNewItemProperty = @{
+   LiteralPath  = $RecallRegPath
+   Name         = 'DisableAIDataAnalysis'
+   Value        = 1
+   PropertyType = 'DWord'
+   Force        = $true
+   Confirm      = $false
+   ErrorAction  = 'Stop'
+}
+$null = (New-ItemProperty @paramNewItemProperty)
+#endregion Recall


### PR DESCRIPTION
Just a quick update to prevent Windows Copilot/Copilot+ and Windows Recall from being installed