### PR TITLE
Enable the Microsoft Defender Removable Drive Scanning

### DIFF
--- a/Windows/ProactiveRemediations/Detection-SetDefenderDisableRemovableDriveScanningOff.ps1
+++ b/Windows/ProactiveRemediations/Detection-SetDefenderDisableRemovableDriveScanningOff.ps1
@@ -1,0 +1,32 @@
+﻿# Detection: Enable the Microsoft Defender Removable Drive Scanning
+# Detection-SetDefenderDisableRemovableDriveScanningOff.ps1
+
+# Where to change something?
+$RegPath = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows Defender\Scan'
+
+try
+{
+   # Does the target exists?
+   if (!(Test-Path -LiteralPath $RegPath -ErrorAction SilentlyContinue))
+   {
+      exit 1
+   }
+   
+   # Is the value correct?
+   $paramGetItemPropertyValue = @{
+      LiteralPath = $RegPath
+      Name        = 'DisableRemovableDriveScanning'
+      ErrorAction = 'SilentlyContinue'
+   }
+   if (!((Get-ItemPropertyValue @paramGetItemPropertyValue) -eq 0))
+   {
+      exit 1
+   }
+   $paramGetItemPropertyValue = $null
+}
+catch
+{
+   exit 1
+}
+
+exit 0

--- a/Windows/ProactiveRemediations/Remediation-SetDefenderDisableRemovableDriveScanningOff.ps1
+++ b/Windows/ProactiveRemediations/Remediation-SetDefenderDisableRemovableDriveScanningOff.ps1
@@ -8,7 +8,7 @@ $RegPath = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows Defender\Scan'
 if ((Test-Path -LiteralPath $RegPath -ErrorAction SilentlyContinue) -ne $true)
 {
    # Create the target path
-   @{
+   $paramNewItem = @{
       Path        = $RegPath
       Force       = $true
       Confirm     = $false

--- a/Windows/ProactiveRemediations/Remediation-SetDefenderDisableRemovableDriveScanningOff.ps1
+++ b/Windows/ProactiveRemediations/Remediation-SetDefenderDisableRemovableDriveScanningOff.ps1
@@ -1,0 +1,32 @@
+﻿# Remediation: Enable the Microsoft Defender Removable Drive Scanning
+# Remediation-SetDefenderDisableRemovableDriveScanningOff.ps1
+
+# Where to change something?
+$RegPath = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows Defender\Scan'
+
+# Does the target exists?
+if ((Test-Path -LiteralPath $RegPath -ErrorAction SilentlyContinue) -ne $true)
+{
+   # Create the target path
+   @{
+      Path        = $RegPath
+      Force       = $true
+      Confirm     = $false
+      ErrorAction = 'SilentlyContinue'
+   }
+   $null = (New-Item @paramNewItem)
+   $paramNewItem = $null
+}
+
+# Enforce the setting we want!
+$paramNewItemProperty = @{
+   LiteralPath  = $RegPath
+   Name         = 'DisableRemovableDriveScanning'
+   Value        = 0
+   PropertyType = 'DWord'
+   Force        = $true
+   Confirm      = $false
+   ErrorAction  = 'SilentlyContinue'
+}
+$null = (New-ItemProperty @paramNewItemProperty)
+$paramNewItemProperty = $null


### PR DESCRIPTION
Simple remediation to enable the Microsoft Defender Removable Drive Scanning