### PR TITLE
Prevent Chrome's and Edge's 4GB AI model from reinstalling itself

### DIFF
--- a/Windows/ProactiveRemediations/Detection-ChromeGenAILocalFoundationalModelSettings.ps1
+++ b/Windows/ProactiveRemediations/Detection-ChromeGenAILocalFoundationalModelSettings.ps1
@@ -1,0 +1,32 @@
+﻿# Check: Prevent Google Chrome's 4GB AI model from reinstalling itself
+# Detection-ChromeGenAILocalFoundationalModelSettings.ps1
+
+$RegPath = 'HKLM:\SOFTWARE\Policies\Google\Chrome'
+
+try
+{
+   $paramTestPath = @{
+      LiteralPath = $RegPath
+      ErrorAction = 'SilentlyContinue'
+   }
+   if (!(Test-Path @paramTestPath))
+   {
+      exit 1
+   }
+   
+   $paramGetItemPropertyValue = @{
+      LiteralPath = $RegPath
+      Name        = 'GenAILocalFoundationalModelSettings'
+      ErrorAction = 'SilentlyContinue'
+   }
+   if (!((Get-ItemPropertyValue @paramGetItemPropertyValue) -eq 1))
+   {
+      exit 1
+   }
+}
+catch
+{
+   exit 1
+}
+
+exit 0

--- a/Windows/ProactiveRemediations/Detection-EdgeGenAILocalFoundationalModelSettings.ps1
+++ b/Windows/ProactiveRemediations/Detection-EdgeGenAILocalFoundationalModelSettings.ps1
@@ -1,0 +1,32 @@
+﻿# Check: Prevent Microsoft Edge's 4GB AI model from reinstalling itself
+# Detection-EdgeGenAILocalFoundationalModelSettings.ps1
+
+$RegPath = 'HKLM:\SOFTWARE\Policies\Microsoft\Edge'
+
+try 
+{
+   $paramTestPath = @{
+      LiteralPath = $RegPath
+      ErrorAction = 'SilentlyContinue'
+   }
+   if (!(Test-Path @paramTestPath))
+   {
+      exit 1
+   }
+   
+   $paramGetItemPropertyValue = @{
+      LiteralPath = $RegPath
+      Name        = 'GenAILocalFoundationalModelSettings'
+      ErrorAction = 'SilentlyContinue'
+   }
+   if (!((Get-ItemPropertyValue @paramGetItemPropertyValue ) -eq 1))
+   {
+      exit 1
+   }
+}
+catch
+{
+   exit 1
+}
+
+exit 0

--- a/Windows/ProactiveRemediations/Remediation-ChromeGenAILocalFoundationalModelSettings.ps1
+++ b/Windows/ProactiveRemediations/Remediation-ChromeGenAILocalFoundationalModelSettings.ps1
@@ -1,0 +1,29 @@
+﻿# Remediate: Prevent Google Chrome's 4GB AI model from reinstalling itself
+# Remediation-ChromeGenAILocalFoundationalModelSettings.ps1
+
+$RegPath = 'HKLM:\SOFTWARE\Policies\Google\Chrome'
+$paramTestPath = @{
+   LiteralPath = $RegPath
+   ErrorAction = 'SilentlyContinue'
+}
+if ((Test-Path @paramTestPath ) -ne $true)
+{
+   $paramNewItem = @{
+      Path        = $RegPath
+      Force       = $true
+      Confirm     = $false
+      ErrorAction = 'SilentlyContinue'
+   }
+   $null = (New-Item @paramNewItem)
+}
+
+$paramNewItemProperty = @{
+   LiteralPath  = $RegPath
+   Name         = 'GenAILocalFoundationalModelSettings'
+   Value        = 1
+   PropertyType = 'DWord'
+   Force        = $true
+   Confirm      = $false
+   ErrorAction  = 'SilentlyContinue'
+}
+$null = (New-ItemProperty @paramNewItemProperty)

--- a/Windows/ProactiveRemediations/Remediation-EdgeGenAILocalFoundationalModelSettings.ps1
+++ b/Windows/ProactiveRemediations/Remediation-EdgeGenAILocalFoundationalModelSettings.ps1
@@ -1,0 +1,29 @@
+﻿# Remediate: Prevent Microsoft Edge's 4GB AI model from reinstalling itself
+# Remediation-EdgeGenAILocalFoundationalModelSettings.ps1
+
+$RegPath = 'HKLM:\SOFTWARE\Policies\Microsoft\Edge'
+$paramTestPath = @{
+   LiteralPath = $RegPath
+   ErrorAction = 'SilentlyContinue'
+}
+if ((Test-Path @paramTestPath ) -ne $true)
+{
+   $paramNewItem = @{
+      Path        = $RegPath
+      Force       = $true
+      Confirm     = $false
+      ErrorAction = 'SilentlyContinue'
+   }
+   $null = (New-Item @paramNewItem)
+}
+
+$paramNewItemProperty = @{
+   LiteralPath  = $RegPath
+   Name         = 'GenAILocalFoundationalModelSettings'
+   Value        = 1
+   PropertyType = 'DWord'
+   Force        = $true
+   Confirm      = $false
+   ErrorAction  = 'SilentlyContinue'
+}
+$null = (New-ItemProperty @paramNewItemProperty)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Prevent Google Chrome's and Microsoft Edge's 4GB AI model from reinstalling itself

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (_non-breaking change which fixes an issue_)
- [ ] New feature (_non-breaking change which adds functionality_)
- [ ] Breaking change (_fix or feature that would cause existing functionality to change_)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [X] I have read the **CONTRIBUTING** document
- [ ] I have added (Pester) tests to cover my changes (_optional_)
